### PR TITLE
Add audit for variable coercion failure

### DIFF
--- a/implementations/apollo-server/README.md
+++ b/implementations/apollo-server/README.md
@@ -3,9 +3,9 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
+<li><b>80</b> audits in total</li>
 <li><span style="font-family: monospace">✅</span> <b>54</b> pass</li>
-<li><span style="font-family: monospace">⚠️</span> <b>25</b> warnings (optional)</li>
+<li><span style="font-family: monospace">⚠️</span> <b>26</b> warnings (optional)</li>
 </ul>
 
 <h2>Passing</h2>
@@ -1030,6 +1030,80 @@ The server <i>SHOULD</i> support these, but is not required.
             "    at Parser.parseOperationDefinition (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/language/parser.js:231:28)"
           ],
           "code": "GRAPHQL_PARSE_FAILED"
+        }
+      }
+    ]
+  }
+}
+</code></pre>
+</details>
+</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json
+<details>
+<summary>Response status code is not 200</summary>
+<pre><code class="lang-json">{
+  "statusText": "Bad Request",
+  "status": 400,
+  "headers": {
+    "x-powered-by": "Express",
+    "etag": "W/\"bb6-gXaURMU/HGIiPsrBiHj0x/xi2Cw\"",
+    "date": "<timestamp>",
+    "content-type": "application/json; charset=utf-8",
+    "content-length": "2998",
+    "connection": "close",
+    "cache-control": "no-store",
+    "access-control-allow-origin": "*"
+  },
+  "body": {
+    "errors": [
+      {
+        "message": "Unknown type \"ID\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 26
+          }
+        ],
+        "extensions": {
+          "stacktrace": [
+            "GraphQLError: Unknown type \"ID\".",
+            "    at Object.NamedType (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/validation/rules/KnownTypeNamesRule.js:65:11)",
+            "    at Object.enter (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/language/visitor.js:301:32)",
+            "    at Object.enter (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/utilities/TypeInfo.js:391:27)",
+            "    at visit (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/language/visitor.js:197:21)",
+            "    at validate (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/validation/validate.js:91:24)",
+            "    at processGraphQLRequest (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/requestPipeline.js:97:34)",
+            "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
+            "    at async internalExecuteOperation (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/ApolloServer.js:585:16)",
+            "    at async runHttpQuery (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/runHttpQuery.js:129:29)",
+            "    at async runPotentiallyBatchedHttpQuery (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/httpBatching.js:34:16)"
+          ],
+          "code": "GRAPHQL_VALIDATION_FAILED"
+        }
+      },
+      {
+        "message": "Variable \"$id\" is never used in operation \"CoerceFailure\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 21
+          }
+        ],
+        "extensions": {
+          "stacktrace": [
+            "GraphQLError: Variable \"$id\" is never used in operation \"CoerceFailure\".",
+            "    at Object.leave (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/validation/rules/NoUnusedVariablesRule.js:39:15)",
+            "    at Object.leave (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/language/visitor.js:324:32)",
+            "    at Object.leave (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/utilities/TypeInfo.js:411:21)",
+            "    at visit (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/language/visitor.js:197:21)",
+            "    at validate (/home/runner/work/graphql-http/graphql-http/node_modules/graphql/validation/validate.js:91:24)",
+            "    at processGraphQLRequest (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/requestPipeline.js:97:34)",
+            "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
+            "    at async internalExecuteOperation (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/ApolloServer.js:585:16)",
+            "    at async runHttpQuery (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/runHttpQuery.js:129:29)",
+            "    at async runPotentiallyBatchedHttpQuery (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/httpBatching.js:34:16)"
+          ],
+          "code": "GRAPHQL_VALIDATION_FAILED"
         }
       }
     ]

--- a/implementations/apollo-server/README.md
+++ b/implementations/apollo-server/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>53</b> pass</li>
+<li><b>79</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>54</b> pass</li>
 <li><span style="font-family: monospace">⚠️</span> <b>25</b> warnings (optional)</li>
 </ul>
 
@@ -63,6 +63,7 @@
 <li><code>51FE</code> SHOULD use 4xx or 5xx status codes on document validation failure when accepting application/graphql-response+json</li>
 <li><code>74FF</code> SHOULD use 400 status code on document validation failure when accepting application/graphql-response+json</li>
 <li><code>5E5B</code> SHOULD not contain the data entry on document validation failure when accepting application/graphql-response+json</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json</li>
 </ol>
 
 <h2>Warnings</h2>

--- a/implementations/apollo-server/report.json
+++ b/implementations/apollo-server/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
+  "total": 80,
   "ok": 54,
-  "warn": 25,
+  "warn": 26,
   "error": 0
 }

--- a/implementations/apollo-server/report.json
+++ b/implementations/apollo-server/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
-  "ok": 53,
+  "total": 79,
+  "ok": 54,
   "warn": 25,
   "error": 0
 }

--- a/implementations/deno/README.md
+++ b/implementations/deno/README.md
@@ -3,9 +3,9 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
+<li><b>79</b> audits in total</li>
 <li><span style="font-family: monospace">✅</span> <b>35</b> pass</li>
-<li><span style="font-family: monospace">⚠️</span> <b>43</b> warnings (optional)</li>
+<li><span style="font-family: monospace">⚠️</span> <b>44</b> warnings (optional)</li>
 </ul>
 
 <h2>Passing</h2>
@@ -819,6 +819,23 @@ The server <i>SHOULD</i> support these, but is not required.
     "content-length": "14"
   },
   "body": null
+}
+</code></pre>
+</details>
+</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json
+<details>
+<summary>Response status code is not 400</summary>
+<pre><code class="lang-json">{
+  "statusText": "Not Acceptable",
+  "status": 406,
+  "headers": {
+    "vary": "Accept-Encoding",
+    "date": "<timestamp>",
+    "content-type": "text/plain;charset=UTF-8",
+    "content-length": "14"
+  },
+  "body": "Not Acceptable"
 }
 </code></pre>
 </details>

--- a/implementations/deno/README.md
+++ b/implementations/deno/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>35</b> pass</li>
+<li><b>80</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>36</b> pass</li>
 <li><span style="font-family: monospace">⚠️</span> <b>44</b> warnings (optional)</li>
 </ul>
 
@@ -41,6 +41,7 @@
 <li><code>F5AF</code> SHOULD use 200 status code if parameters are invalid when accepting application/json</li>
 <li><code>572B</code> SHOULD use 200 status code on document parsing failure when accepting application/json</li>
 <li><code>FDE2</code> SHOULD use 200 status code on document validation failure when accepting application/json</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json</li>
 <li><code>60AA</code> SHOULD use 4xx or 5xx status codes on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>3E36</code> SHOULD use 4xx or 5xx status codes if parameters are invalid when accepting application/graphql-response+json</li>
 <li><code>865D</code> SHOULD use 4xx or 5xx status codes on document parsing failure when accepting application/graphql-response+json</li>

--- a/implementations/deno/report.json
+++ b/implementations/deno/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
-  "ok": 35,
+  "total": 80,
+  "ok": 36,
   "warn": 44,
   "error": 0
 }

--- a/implementations/deno/report.json
+++ b/implementations/deno/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
+  "total": 79,
   "ok": 35,
-  "warn": 43,
+  "warn": 44,
   "error": 0
 }

--- a/implementations/express-graphql/README.md
+++ b/implementations/express-graphql/README.md
@@ -3,9 +3,9 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
+<li><b>80</b> audits in total</li>
 <li><span style="font-family: monospace">✅</span> <b>46</b> pass</li>
-<li><span style="font-family: monospace">⚠️</span> <b>33</b> warnings (optional)</li>
+<li><span style="font-family: monospace">⚠️</span> <b>34</b> warnings (optional)</li>
 </ul>
 
 <h2>Passing</h2>
@@ -843,6 +843,46 @@ The server <i>SHOULD</i> support these, but is not required.
           {
             "line": 1,
             "column": 4
+          }
+        ]
+      }
+    ]
+  }
+}
+</code></pre>
+</details>
+</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json
+<details>
+<summary>Response status code is not 200</summary>
+<pre><code class="lang-json">{
+  "statusText": "Bad Request",
+  "status": 400,
+  "headers": {
+    "x-powered-by": "Express",
+    "etag": "W/\"c6-jKvd+KIdPY2/2i/wYj0ck5PZF20\"",
+    "date": "<timestamp>",
+    "content-type": "application/json; charset=utf-8",
+    "content-length": "198",
+    "connection": "close"
+  },
+  "body": {
+    "errors": [
+      {
+        "message": "Unknown type \"ID\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 26
+          }
+        ]
+      },
+      {
+        "message": "Variable \"$id\" is never used in operation \"CoerceFailure\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 21
           }
         ]
       }

--- a/implementations/express-graphql/README.md
+++ b/implementations/express-graphql/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>45</b> pass</li>
+<li><b>79</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>46</b> pass</li>
 <li><span style="font-family: monospace">⚠️</span> <b>33</b> warnings (optional)</li>
 </ul>
 
@@ -55,6 +55,7 @@
 <li><code>51FE</code> SHOULD use 4xx or 5xx status codes on document validation failure when accepting application/graphql-response+json</li>
 <li><code>74FF</code> SHOULD use 400 status code on document validation failure when accepting application/graphql-response+json</li>
 <li><code>5E5B</code> SHOULD not contain the data entry on document validation failure when accepting application/graphql-response+json</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json</li>
 </ol>
 
 <h2>Warnings</h2>

--- a/implementations/express-graphql/report.json
+++ b/implementations/express-graphql/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
+  "total": 80,
   "ok": 46,
-  "warn": 33,
+  "warn": 34,
   "error": 0
 }

--- a/implementations/express-graphql/report.json
+++ b/implementations/express-graphql/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
-  "ok": 45,
+  "total": 79,
+  "ok": 46,
   "warn": 33,
   "error": 0
 }

--- a/implementations/graph-client/README.md
+++ b/implementations/graph-client/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>78</b> pass</li>
+<li><b>79</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>79</b> pass</li>
 </ul>
 
 <h2>Passing</h2>
@@ -87,5 +87,6 @@
 <li><code>51FE</code> SHOULD use 4xx or 5xx status codes on document validation failure when accepting application/graphql-response+json</li>
 <li><code>74FF</code> SHOULD use 400 status code on document validation failure when accepting application/graphql-response+json</li>
 <li><code>5E5B</code> SHOULD not contain the data entry on document validation failure when accepting application/graphql-response+json</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json</li>
 </ol>
 

--- a/implementations/graph-client/README.md
+++ b/implementations/graph-client/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>79</b> pass</li>
+<li><b>80</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>80</b> pass</li>
 </ul>
 
 <h2>Passing</h2>
@@ -76,6 +76,7 @@
 <li><code>F5AF</code> SHOULD use 200 status code if parameters are invalid when accepting application/json</li>
 <li><code>572B</code> SHOULD use 200 status code on document parsing failure when accepting application/json</li>
 <li><code>FDE2</code> SHOULD use 200 status code on document validation failure when accepting application/json</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json</li>
 <li><code>60AA</code> SHOULD use 4xx or 5xx status codes on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>2163</code> SHOULD use 400 status code on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>3E36</code> SHOULD use 4xx or 5xx status codes if parameters are invalid when accepting application/graphql-response+json</li>

--- a/implementations/graph-client/report.json
+++ b/implementations/graph-client/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
-  "ok": 78,
+  "total": 79,
+  "ok": 79,
   "warn": 0,
   "error": 0
 }

--- a/implementations/graph-client/report.json
+++ b/implementations/graph-client/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
-  "ok": 79,
+  "total": 80,
+  "ok": 80,
   "warn": 0,
   "error": 0
 }

--- a/implementations/graphql-helix/README.md
+++ b/implementations/graphql-helix/README.md
@@ -3,9 +3,9 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
+<li><b>80</b> audits in total</li>
 <li><span style="font-family: monospace">✅</span> <b>50</b> pass</li>
-<li><span style="font-family: monospace">⚠️</span> <b>29</b> warnings (optional)</li>
+<li><span style="font-family: monospace">⚠️</span> <b>30</b> warnings (optional)</li>
 </ul>
 
 <h2>Passing</h2>
@@ -722,6 +722,45 @@ The server <i>SHOULD</i> support these, but is not required.
           {
             "line": 1,
             "column": 4
+          }
+        ]
+      }
+    ]
+  }
+}
+</code></pre>
+</details>
+</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json
+<details>
+<summary>Response status code is not 200</summary>
+<pre><code class="lang-json">{
+  "statusText": "Bad Request",
+  "status": 400,
+  "headers": {
+    "x-powered-by": "Express",
+    "date": "<timestamp>",
+    "content-type": "application/json",
+    "content-length": "198",
+    "connection": "close"
+  },
+  "body": {
+    "errors": [
+      {
+        "message": "Unknown type \"ID\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 26
+          }
+        ]
+      },
+      {
+        "message": "Variable \"$id\" is never used in operation \"CoerceFailure\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 21
           }
         ]
       }

--- a/implementations/graphql-helix/README.md
+++ b/implementations/graphql-helix/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>49</b> pass</li>
+<li><b>79</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>50</b> pass</li>
 <li><span style="font-family: monospace">⚠️</span> <b>29</b> warnings (optional)</li>
 </ul>
 
@@ -59,6 +59,7 @@
 <li><code>51FE</code> SHOULD use 4xx or 5xx status codes on document validation failure when accepting application/graphql-response+json</li>
 <li><code>74FF</code> SHOULD use 400 status code on document validation failure when accepting application/graphql-response+json</li>
 <li><code>5E5B</code> SHOULD not contain the data entry on document validation failure when accepting application/graphql-response+json</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json</li>
 </ol>
 
 <h2>Warnings</h2>

--- a/implementations/graphql-helix/report.json
+++ b/implementations/graphql-helix/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
-  "ok": 49,
+  "total": 79,
+  "ok": 50,
   "warn": 29,
   "error": 0
 }

--- a/implementations/graphql-helix/report.json
+++ b/implementations/graphql-helix/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
+  "total": 80,
   "ok": 50,
-  "warn": 29,
+  "warn": 30,
   "error": 0
 }

--- a/implementations/graphql-yoga/README.md
+++ b/implementations/graphql-yoga/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>78</b> pass</li>
+<li><b>79</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>79</b> pass</li>
 </ul>
 
 <h2>Passing</h2>
@@ -87,5 +87,6 @@
 <li><code>51FE</code> SHOULD use 4xx or 5xx status codes on document validation failure when accepting application/graphql-response+json</li>
 <li><code>74FF</code> SHOULD use 400 status code on document validation failure when accepting application/graphql-response+json</li>
 <li><code>5E5B</code> SHOULD not contain the data entry on document validation failure when accepting application/graphql-response+json</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json</li>
 </ol>
 

--- a/implementations/graphql-yoga/README.md
+++ b/implementations/graphql-yoga/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>79</b> pass</li>
+<li><b>80</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>80</b> pass</li>
 </ul>
 
 <h2>Passing</h2>
@@ -76,6 +76,7 @@
 <li><code>F5AF</code> SHOULD use 200 status code if parameters are invalid when accepting application/json</li>
 <li><code>572B</code> SHOULD use 200 status code on document parsing failure when accepting application/json</li>
 <li><code>FDE2</code> SHOULD use 200 status code on document validation failure when accepting application/json</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json</li>
 <li><code>60AA</code> SHOULD use 4xx or 5xx status codes on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>2163</code> SHOULD use 400 status code on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>3E36</code> SHOULD use 4xx or 5xx status codes if parameters are invalid when accepting application/graphql-response+json</li>

--- a/implementations/graphql-yoga/report.json
+++ b/implementations/graphql-yoga/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
-  "ok": 78,
+  "total": 79,
+  "ok": 79,
   "warn": 0,
   "error": 0
 }

--- a/implementations/graphql-yoga/report.json
+++ b/implementations/graphql-yoga/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
-  "ok": 79,
+  "total": 80,
+  "ok": 80,
   "warn": 0,
   "error": 0
 }

--- a/implementations/hotchocolate/README.md
+++ b/implementations/hotchocolate/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>77</b> pass</li>
+<li><b>80</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>78</b> pass</li>
 <li><span style="font-family: monospace">⚠️</span> <b>2</b> warnings (optional)</li>
 </ul>
 
@@ -75,6 +75,7 @@
 <li><code>F5AF</code> SHOULD use 200 status code if parameters are invalid when accepting application/json</li>
 <li><code>572B</code> SHOULD use 200 status code on document parsing failure when accepting application/json</li>
 <li><code>FDE2</code> SHOULD use 200 status code on document validation failure when accepting application/json</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json</li>
 <li><code>60AA</code> SHOULD use 4xx or 5xx status codes on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>2163</code> SHOULD use 400 status code on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>3E36</code> SHOULD use 4xx or 5xx status codes if parameters are invalid when accepting application/graphql-response+json</li>

--- a/implementations/hotchocolate/README.md
+++ b/implementations/hotchocolate/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>76</b> pass</li>
+<li><b>79</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>77</b> pass</li>
 <li><span style="font-family: monospace">⚠️</span> <b>2</b> warnings (optional)</li>
 </ul>
 
@@ -86,6 +86,7 @@
 <li><code>51FE</code> SHOULD use 4xx or 5xx status codes on document validation failure when accepting application/graphql-response+json</li>
 <li><code>74FF</code> SHOULD use 400 status code on document validation failure when accepting application/graphql-response+json</li>
 <li><code>5E5B</code> SHOULD not contain the data entry on document validation failure when accepting application/graphql-response+json</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json</li>
 </ol>
 
 <h2>Warnings</h2>

--- a/implementations/hotchocolate/report.json
+++ b/implementations/hotchocolate/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
-  "ok": 77,
+  "total": 80,
+  "ok": 78,
   "warn": 2,
   "error": 0
 }

--- a/implementations/hotchocolate/report.json
+++ b/implementations/hotchocolate/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
-  "ok": 76,
+  "total": 79,
+  "ok": 77,
   "warn": 2,
   "error": 0
 }

--- a/implementations/mercurius/README.md
+++ b/implementations/mercurius/README.md
@@ -3,9 +3,9 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
+<li><b>79</b> audits in total</li>
 <li><span style="font-family: monospace">✅</span> <b>49</b> pass</li>
-<li><span style="font-family: monospace">⚠️</span> <b>28</b> warnings (optional)</li>
+<li><span style="font-family: monospace">⚠️</span> <b>29</b> warnings (optional)</li>
 <li><span style="font-family: monospace">❌</span> <b>1</b> errors (required)</li>
 </ul>
 
@@ -742,6 +742,45 @@ The server <i>SHOULD</i> support these, but is not required.
           {
             "line": 1,
             "column": 4
+          }
+        ]
+      }
+    ],
+    "data": null
+  }
+}
+</code></pre>
+</details>
+</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json
+<details>
+<summary>Response status code is not 400</summary>
+<pre><code class="lang-json">{
+  "statusText": "OK",
+  "status": 200,
+  "headers": {
+    "date": "<timestamp>",
+    "content-type": "application/json; charset=utf-8",
+    "content-length": "210",
+    "connection": "close"
+  },
+  "body": {
+    "errors": [
+      {
+        "message": "Unknown type \"ID\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 26
+          }
+        ]
+      },
+      {
+        "message": "Variable \"$id\" is never used in operation \"CoerceFailure\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 21
           }
         ]
       }

--- a/implementations/mercurius/README.md
+++ b/implementations/mercurius/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>49</b> pass</li>
+<li><b>80</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>50</b> pass</li>
 <li><span style="font-family: monospace">⚠️</span> <b>29</b> warnings (optional)</li>
 <li><span style="font-family: monospace">❌</span> <b>1</b> errors (required)</li>
 </ul>
@@ -52,6 +52,7 @@
 <li><code>9043</code> SHOULD use 400 status code on array {extensions} parameter when accepting application/graphql-response+json</li>
 <li><code>428F</code> SHOULD allow map {extensions} parameter when accepting application/graphql-response+json</li>
 <li><code>1B7A</code> MUST allow map {extensions} parameter when accepting application/json</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json</li>
 <li><code>60AA</code> SHOULD use 4xx or 5xx status codes on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>2163</code> SHOULD use 400 status code on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>3E36</code> SHOULD use 4xx or 5xx status codes if parameters are invalid when accepting application/graphql-response+json</li>

--- a/implementations/mercurius/report.json
+++ b/implementations/mercurius/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
-  "ok": 49,
+  "total": 80,
+  "ok": 50,
   "warn": 29,
   "error": 1
 }

--- a/implementations/mercurius/report.json
+++ b/implementations/mercurius/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
+  "total": 79,
   "ok": 49,
-  "warn": 28,
+  "warn": 29,
   "error": 1
 }

--- a/implementations/pioneer/README.md
+++ b/implementations/pioneer/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>75</b> pass</li>
+<li><b>80</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>76</b> pass</li>
 <li><span style="font-family: monospace">⚠️</span> <b>4</b> warnings (optional)</li>
 </ul>
 
@@ -74,6 +74,7 @@
 <li><code>428F</code> SHOULD allow map {extensions} parameter when accepting application/graphql-response+json</li>
 <li><code>1B7A</code> MUST allow map {extensions} parameter when accepting application/json</li>
 <li><code>F5AF</code> SHOULD use 200 status code if parameters are invalid when accepting application/json</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json</li>
 <li><code>60AA</code> SHOULD use 4xx or 5xx status codes on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>2163</code> SHOULD use 400 status code on JSON parsing failure when accepting application/graphql-response+json</li>
 <li><code>3E36</code> SHOULD use 4xx or 5xx status codes if parameters are invalid when accepting application/graphql-response+json</li>

--- a/implementations/pioneer/README.md
+++ b/implementations/pioneer/README.md
@@ -3,9 +3,9 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
+<li><b>79</b> audits in total</li>
 <li><span style="font-family: monospace">✅</span> <b>75</b> pass</li>
-<li><span style="font-family: monospace">⚠️</span> <b>3</b> warnings (optional)</li>
+<li><span style="font-family: monospace">⚠️</span> <b>4</b> warnings (optional)</li>
 </ul>
 
 <h2>Passing</h2>
@@ -155,6 +155,36 @@ The server <i>SHOULD</i> support these, but is not required.
       {
         "path": [],
         "message": "Operation of this type is not allowed and has been blocked"
+      }
+    ]
+  }
+}
+</code></pre>
+</details>
+</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json
+<details>
+<summary>Response status code is not 400</summary>
+<pre><code class="lang-json">{
+  "statusText": "OK",
+  "status": 200,
+  "headers": {
+    "date": "<timestamp>",
+    "content-type": "application/graphql-response+json; charset=utf-8, application/graphql-response+json",
+    "content-length": "136",
+    "connection": "close"
+  },
+  "body": {
+    "errors": [
+      {
+        "path": [],
+        "message": "Variable \"$id\" is never used in operation \"CoerceFailure\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 21
+          }
+        ]
       }
     ]
   }

--- a/implementations/pioneer/report.json
+++ b/implementations/pioneer/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
+  "total": 79,
   "ok": 75,
-  "warn": 3,
+  "warn": 4,
   "error": 0
 }

--- a/implementations/pioneer/report.json
+++ b/implementations/pioneer/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
-  "ok": 75,
+  "total": 80,
+  "ok": 76,
   "warn": 4,
   "error": 0
 }

--- a/implementations/postgraphile/README.md
+++ b/implementations/postgraphile/README.md
@@ -3,9 +3,9 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>79</b> audits in total</li>
+<li><b>80</b> audits in total</li>
 <li><span style="font-family: monospace">✅</span> <b>46</b> pass</li>
-<li><span style="font-family: monospace">⚠️</span> <b>33</b> warnings (optional)</li>
+<li><span style="font-family: monospace">⚠️</span> <b>34</b> warnings (optional)</li>
 </ul>
 
 <h2>Passing</h2>
@@ -805,6 +805,35 @@ The server <i>SHOULD</i> support these, but is not required.
           {
             "line": 1,
             "column": 4
+          }
+        ]
+      }
+    ]
+  }
+}
+</code></pre>
+</details>
+</li>
+<li><code>7B9B</code> SHOULD use a status code of 200 on variable coercion failure when accepting application/json
+<details>
+<summary>Response status code is not 200</summary>
+<pre><code class="lang-json">{
+  "statusText": "Bad Request",
+  "status": 400,
+  "headers": {
+    "date": "<timestamp>",
+    "content-type": "application/json; charset=utf-8",
+    "content-length": "126",
+    "connection": "close"
+  },
+  "body": {
+    "errors": [
+      {
+        "message": "Variable \"$id\" is never used in operation \"CoerceFailure\".",
+        "locations": [
+          {
+            "line": 1,
+            "column": 21
           }
         ]
       }

--- a/implementations/postgraphile/README.md
+++ b/implementations/postgraphile/README.md
@@ -3,8 +3,8 @@
 <h1>GraphQL over HTTP audit report</h1>
 
 <ul>
-<li><b>78</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>45</b> pass</li>
+<li><b>79</b> audits in total</li>
+<li><span style="font-family: monospace">✅</span> <b>46</b> pass</li>
 <li><span style="font-family: monospace">⚠️</span> <b>33</b> warnings (optional)</li>
 </ul>
 
@@ -55,6 +55,7 @@
 <li><code>51FE</code> SHOULD use 4xx or 5xx status codes on document validation failure when accepting application/graphql-response+json</li>
 <li><code>74FF</code> SHOULD use 400 status code on document validation failure when accepting application/graphql-response+json</li>
 <li><code>5E5B</code> SHOULD not contain the data entry on document validation failure when accepting application/graphql-response+json</li>
+<li><code>86EE</code> SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json</li>
 </ol>
 
 <h2>Warnings</h2>

--- a/implementations/postgraphile/report.json
+++ b/implementations/postgraphile/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 79,
+  "total": 80,
   "ok": 46,
-  "warn": 33,
+  "warn": 34,
   "error": 0
 }

--- a/implementations/postgraphile/report.json
+++ b/implementations/postgraphile/report.json
@@ -1,6 +1,6 @@
 {
-  "total": 78,
-  "ok": 45,
+  "total": 79,
+  "ok": 46,
   "warn": 33,
   "error": 0
 }

--- a/src/__tests__/__snapshots__/audits.ts.snap
+++ b/src/__tests__/__snapshots__/audits.ts.snap
@@ -271,6 +271,10 @@ exports[`should not change globally unique audit ids 1`] = `
     "name": "SHOULD use 200 status code on document validation failure when accepting application/json",
   },
   {
+    "id": "7B9B",
+    "name": "SHOULD use a status code of 200 on variable coercion failure when accepting application/json",
+  },
+  {
     "id": "60AA",
     "name": "SHOULD use 4xx or 5xx status codes on JSON parsing failure when accepting application/graphql-response+json",
   },

--- a/src/__tests__/__snapshots__/audits.ts.snap
+++ b/src/__tests__/__snapshots__/audits.ts.snap
@@ -314,5 +314,9 @@ exports[`should not change globally unique audit ids 1`] = `
     "id": "5E5B",
     "name": "SHOULD not contain the data entry on document validation failure when accepting application/graphql-response+json",
   },
+  {
+    "id": "86EE",
+    "name": "SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json",
+  },
 ]
 `;

--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -936,7 +936,7 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
         });
         ressert(res).status.toBe(400);
       },
-    )
+    ),
     // TODO: how to fail and have the data entry?
     // audit('EE52', 'MUST use 2xx status code if response contains the data entry and it is not null when accepting application/graphql-response+json'),
     // TODO: how to make an unauthorized request?

--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -919,6 +919,24 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
         await ressert(res).bodyAsExecutionResult.data.toBe(undefined);
       },
     ),
+    audit(
+      '86EE',
+      'SHOULD use a status code of 400 on variable coercion failure when accepting application/graphql-response+json',
+      async () => {
+        const res = await fetchFn(await getUrl(opts.url), {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/graphql-response+json',
+          },
+          body: JSON.stringify({
+            query: 'query CoerceFailure($id: ID!){ __typename }',
+            variables: { id: null },
+          }),
+        });
+        ressert(res).status.toBe(400);
+      },
+    )
     // TODO: how to fail and have the data entry?
     // audit('EE52', 'MUST use 2xx status code if response contains the data entry and it is not null when accepting application/graphql-response+json'),
     // TODO: how to make an unauthorized request?

--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -731,6 +731,24 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
         ressert(res).status.toBe(200);
       },
     ),
+    audit(
+      '7B9B',
+      'SHOULD use a status code of 200 on variable coercion failure when accepting application/json',
+      async () => {
+        const res = await fetchFn(await getUrl(opts.url), {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json',
+          },
+          body: JSON.stringify({
+            query: 'query CoerceFailure($id: ID!){ __typename }',
+            variables: { id: null },
+          }),
+        });
+        ressert(res).status.toBe(200);
+      },
+    ),
     // Response application/graphql-response+json
     audit(
       // TODO: convert to MUST after watershed


### PR DESCRIPTION
[From the spec](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#variable-coercion-failure):
>If [CoerceVariableValues()](https://spec.graphql.org/draft/#CoerceVariableValues()) raises a GraphQL request error, the server SHOULD NOT execute the request and SHOULD return a status code of 400 (Bad Request).

Fixes #57

Should I be also "should not"ing the request execution (and how can I accomplish that)?
I'm assuming I don't update the audit results (it looks like that's in a GH workflow) but let me know if there are any other changes that should come with PR.