### PR TITLE
Add recipe to audit servers with Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,7 +740,7 @@ for (const audit of serverAudits({
 <summary><a href="#audit-deno">🔗</a> Audit for servers usage in <a href="https://deno.land">Deno</a> environment</summary>
 
 ```ts
-import { serverAudits } from 'https://esm.sh/graphql-http';
+import { serverAudits } from 'npm:graphql-http';
 
 for (const audit of serverAudits({
   url: 'http://localhost:4000/graphql',
@@ -758,6 +758,8 @@ for (const audit of serverAudits({
   });
 }
 ```
+
+Put the above contents in a file and run it with `deno test --allow-net`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -754,7 +754,10 @@ for (const audit of serverAudits({
     if (result.status === 'warn') {
       console.warn(result.reason); // or throw if you want full compliance (warnings are not requirements)
     }
-    // result.status === 'ok'
+    // Avoid leaking resources
+    if ('body' in result && result.body instanceof ReadableStream) {
+      await result.body.cancel();
+    }
   });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -736,6 +736,31 @@ for (const audit of serverAudits({
 
 </details>
 
+<details id="audit-deno">
+<summary><a href="#audit-deno">🔗</a> Audit for servers usage in <a href="https://deno.land">Deno</a> environment</summary>
+
+```ts
+import { serverAudits } from 'https://esm.sh/graphql-http';
+
+for (const audit of serverAudits({
+  url: 'http://localhost:4000/graphql',
+  fetchFn: fetch,
+})) {
+  Deno.test(audit.name, async () => {
+    const result = await audit.fn();
+    if (result.status === 'error') {
+      throw result.reason;
+    }
+    if (result.status === 'warn') {
+      console.warn(result.reason); // or throw if you want full compliance (warnings are not requirements)
+    }
+    // result.status === 'ok'
+  });
+}
+```
+
+</details>
+
 ## Only [GraphQL over HTTP](https://graphql.github.io/graphql-over-http/)
 
 This is the official [GraphQL over HTTP spec](https://graphql.github.io/graphql-over-http/) reference implementation and as such follows the specification strictly without any additional features (like file uploads, @stream/@defer directives and subscriptions).


### PR DESCRIPTION
I tried to setup audit tests as described in the Jest example, but found the setup of Jest itself quite cumbersome. Thus, I tried to see if Deno was simpler.

~Unfortunately, the example does not work as of now. You can try writing the example code to a file `test.ts` and run it with `deno test test.ts`. I am currently getting the following error:~

```
error: Uncaught SyntaxError: The requested module '/v111/graphql@16.6.0/deno/graphql.js' does not provide an export named 'GraphQLError'
    at <anonymous> (https://esm.sh/v111/graphql-http@1.16.0/deno/graphql-http.js:2:90)
```

I found that using [npm specifiers](https://deno.land/manual@v1.31.3/node/npm_specifiers#npm-specifiers) fixes the above mentioned error with the missing export.