### PR TITLE
fix(audits/server): Prefer using POST

### DIFF
--- a/implementations/apollo-server/README.md
+++ b/implementations/apollo-server/README.md
@@ -4,8 +4,8 @@
 
 <ul>
 <li><b>37</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>30</b> pass</li>
-<li><span style="font-family: monospace">⚠️</span> <b>7</b> warnings (optional)</li>
+<li><span style="font-family: monospace">✅</span> <b>31</b> pass</li>
+<li><span style="font-family: monospace">⚠️</span> <b>6</b> warnings (optional)</li>
 </ul>
 
 <h2>Passing</h2>
@@ -13,6 +13,7 @@
 <li><code>22EB</code> SHOULD accept application/graphql-response+json and match the content-type</li>
 <li><code>4655</code> MUST accept application/json and match the content-type</li>
 <li><code>47DE</code> SHOULD accept */* and use application/json for the content-type</li>
+<li><code>80D8</code> SHOULD assume application/json content-type when accept is missing</li>
 <li><code>82A3</code> MUST use utf-8 encoding when responding</li>
 <li><code>BF61</code> MUST accept utf-8 encoded request</li>
 <li><code>78D5</code> MUST assume utf-8 in request if encoding is unspecified</li>
@@ -45,44 +46,6 @@
 <h2>Warnings</h2>
 The server <i>SHOULD</i> support these, but is not required.
 <ol>
-<li><code>80D8</code> SHOULD assume application/json content-type when accept is missing
-<details>
-<summary>Response status code is not 200</summary>
-<pre><code class="lang-json">{
-  "statusText": "Bad Request",
-  "status": 400,
-  "headers": {
-    "x-powered-by": "Express",
-    "etag": "W/\"5b5-gDRXf8j0lbjWbmQpeY60iENT2cI\"",
-    "date": "<timestamp>",
-    "content-type": "application/json; charset=utf-8",
-    "content-length": "1461",
-    "connection": "close",
-    "access-control-allow-origin": "*"
-  },
-  "body": {
-    "errors": [
-      {
-        "message": "This operation has been blocked as a potential Cross-Site Request Forgery (CSRF). Please either specify a 'content-type' header (with a type that is not one of application/x-www-form-urlencoded, multipart/form-data, text/plain) or provide a non-empty value for one of the following headers: x-apollo-operation-name, apollo-require-preflight\n",
-        "extensions": {
-          "stacktrace": [
-            "BadRequestError: This operation has been blocked as a potential Cross-Site Request Forgery (CSRF). Please either specify a 'content-type' header (with a type that is not one of application/x-www-form-urlencoded, multipart/form-data, text/plain) or provide a non-empty value for one of the following headers: x-apollo-operation-name, apollo-require-preflight",
-            "",
-            "    at new GraphQLErrorWithCode (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/internalErrorClasses.js:7:9)",
-            "    at new BadRequestError (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/internalErrorClasses.js:75:9)",
-            "    at preventCsrf (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/preventCsrf.js:29:11)",
-            "    at ApolloServer.executeHTTPGraphQLRequest (file:///home/runner/work/graphql-http/graphql-http/node_modules/@apollo/server/dist/esm/ApolloServer.js:478:17)",
-            "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
-          ],
-          "code": "BAD_REQUEST"
-        }
-      }
-    ]
-  }
-}
-</code></pre>
-</details>
-</li>
 <li><code>5A70</code> MAY accept application/x-www-form-urlencoded formatted GET requests
 <details>
 <summary>Response status code is not 200</summary>

--- a/implementations/apollo-server/report.json
+++ b/implementations/apollo-server/report.json
@@ -1,6 +1,6 @@
 {
   "total": 37,
-  "ok": 30,
-  "warn": 7,
+  "ok": 31,
+  "warn": 6,
   "error": 0
 }

--- a/implementations/postgraphile/README.md
+++ b/implementations/postgraphile/README.md
@@ -4,14 +4,15 @@
 
 <ul>
 <li><b>37</b> audits in total</li>
-<li><span style="font-family: monospace">✅</span> <b>29</b> pass</li>
-<li><span style="font-family: monospace">⚠️</span> <b>8</b> warnings (optional)</li>
+<li><span style="font-family: monospace">✅</span> <b>30</b> pass</li>
+<li><span style="font-family: monospace">⚠️</span> <b>7</b> warnings (optional)</li>
 </ul>
 
 <h2>Passing</h2>
 <ol>
 <li><code>4655</code> MUST accept application/json and match the content-type</li>
 <li><code>47DE</code> SHOULD accept */* and use application/json for the content-type</li>
+<li><code>80D8</code> SHOULD assume application/json content-type when accept is missing</li>
 <li><code>82A3</code> MUST use utf-8 encoding when responding</li>
 <li><code>BF61</code> MUST accept utf-8 encoded request</li>
 <li><code>78D5</code> MUST assume utf-8 in request if encoding is unspecified</li>
@@ -60,30 +61,6 @@ The server <i>SHOULD</i> support these, but is not required.
     "data": {
       "__typename": "Query"
     }
-  }
-}
-</code></pre>
-</details>
-</li>
-<li><code>80D8</code> SHOULD assume application/json content-type when accept is missing
-<details>
-<summary>Response status code is not 200</summary>
-<pre><code class="lang-json">{
-  "statusText": "Method Not Allowed",
-  "status": 405,
-  "headers": {
-    "date": "<timestamp>",
-    "content-type": "application/json; charset=utf-8",
-    "content-length": "60",
-    "connection": "close",
-    "allow": "POST, OPTIONS"
-  },
-  "body": {
-    "errors": [
-      {
-        "message": "Only `POST` requests are allowed."
-      }
-    ]
   }
 }
 </code></pre>

--- a/implementations/postgraphile/report.json
+++ b/implementations/postgraphile/report.json
@@ -1,6 +1,6 @@
 {
   "total": 37,
-  "ok": 29,
-  "warn": 8,
+  "ok": 30,
+  "warn": 7,
   "error": 0
 }

--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -94,10 +94,14 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
       '80D8',
       'SHOULD assume application/json content-type when accept is missing',
       async () => {
-        const url = new URL(await getUrl(opts.url));
-        url.searchParams.set('query', '{ __typename }');
+        const res = await fetchFn(await getUrl(opts.url), {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ query: '{ __typename }' }),
+        });
 
-        const res = await fetchFn(url.toString());
         ressert(res).status.toBe(200);
         ressert(res).header('content-type').toContain('application/json');
       },


### PR DESCRIPTION
The servers MUST support `POST` requests, but may not support `GET` requests. Meaning, all SHOULDs should use `POST` methods.