### PR TITLE
fix(handler): Don't export `makeResponse`, `getAcceptableMediaType` or `isResponse`

### DIFF
--- a/docs/modules/handler.md
+++ b/docs/modules/handler.md
@@ -24,7 +24,6 @@
 ### Functions
 
 - [createHandler](handler.md#createhandler)
-- [isResponse](handler.md#isresponse)
 
 ## Server
 
@@ -216,21 +215,3 @@ console.log('Listening to port 4000');
 #### Returns
 
 [`Handler`](handler.md#handler)<`RequestRaw`, `RequestContext`\>
-
-___
-
-### isResponse
-
-▸ **isResponse**(`val`): val is Response
-
-Checks whether the passed value is the `graphql-http` server agnostic response.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `val` | `unknown` |
-
-#### Returns
-
-val is Response

--- a/docs/modules/handler.md
+++ b/docs/modules/handler.md
@@ -12,7 +12,6 @@
 
 ### Type Aliases
 
-- [AcceptableMediaType](handler.md#acceptablemediatype)
 - [FormatError](handler.md#formaterror)
 - [Handler](handler.md#handler)
 - [OperationArgs](handler.md#operationargs)
@@ -25,19 +24,9 @@
 ### Functions
 
 - [createHandler](handler.md#createhandler)
-- [getAcceptableMediaType](handler.md#getacceptablemediatype)
 - [isResponse](handler.md#isresponse)
-- [makeResponse](handler.md#makeresponse)
 
 ## Server
-
-### AcceptableMediaType
-
-Ƭ **AcceptableMediaType**: ``"application/graphql-response+json"`` \| ``"application/json"``
-
-Request's Media-Type that the server accepts.
-
-___
 
 ### FormatError
 
@@ -230,25 +219,6 @@ console.log('Listening to port 4000');
 
 ___
 
-### getAcceptableMediaType
-
-▸ **getAcceptableMediaType**(`acceptHeader`): [`AcceptableMediaType`](handler.md#acceptablemediatype) \| ``null``
-
-Inspects the request and detects the appropriate/acceptable Media-Type
-looking at the `Accept` header while complying with the GraphQL over HTTP spec.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `acceptHeader` | `undefined` \| ``null`` \| `string` |
-
-#### Returns
-
-[`AcceptableMediaType`](handler.md#acceptablemediatype) \| ``null``
-
-___
-
 ### isResponse
 
 ▸ **isResponse**(`val`): val is Response
@@ -264,31 +234,3 @@ Checks whether the passed value is the `graphql-http` server agnostic response.
 #### Returns
 
 val is Response
-
-___
-
-### makeResponse
-
-▸ **makeResponse**(`resultOrErrors`, `acceptedMediaType`, `formatError`): [`Response`](handler.md#response)
-
-Creates an appropriate GraphQL over HTTP response following the provided arguments.
-
-If the first argument is an `ExecutionResult`, the operation will be treated as "successful".
-
-If the first argument is (an array of) `GraphQLError`, or an `ExecutionResult` without the `data` field, it will be treated
-the response will be constructed with the help of `acceptedMediaType` complying with the GraphQL over HTTP spec.
-
-If the first argument is an `Error`, the operation will be treated as a bad request responding with `400: Bad Request` and the
-error will be present in the `ExecutionResult` style.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `resultOrErrors` | readonly `GraphQLError`[] \| `Readonly`<`ExecutionResult`<`ObjMap`<`unknown`\>, `ObjMap`<`unknown`\>\>\> \| `Readonly`<`GraphQLError`\> \| `Readonly`<`Error`\> |
-| `acceptedMediaType` | [`AcceptableMediaType`](handler.md#acceptablemediatype) |
-| `formatError` | [`FormatError`](handler.md#formaterror) |
-
-#### Returns
-
-[`Response`](handler.md#response)

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -123,12 +123,8 @@ export interface ResponseInit {
  */
 export type Response = readonly [body: ResponseBody | null, init: ResponseInit];
 
-/**
- * Checks whether the passed value is the `graphql-http` server agnostic response.
- *
- * @category Server
- */
-export function isResponse(val: unknown): val is Response {
+/** Checks whether the passed value is the `graphql-http` server agnostic response. */
+function isResponse(val: unknown): val is Response {
   // TODO: make sure the contents of init match ResponseInit
   return (
     Array.isArray(val) &&


### PR DESCRIPTION
I don't expect this to be a breaking change because its very undocumented, not known and therefore (I think) unused.