### PR TITLE
fix(client): `graphql` module is not required for runtime

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,6 @@
  */
 
 import type { ExecutionResult } from 'graphql';
-import { GraphQLError } from 'graphql';
 
 /** @private */
 export function extendedTypeof(
@@ -40,21 +39,6 @@ export function isObject(val: unknown): val is Record<
 }
 
 /** @private */
-export function areGraphQLErrors(obj: unknown): obj is readonly GraphQLError[] {
-  return (
-    Array.isArray(obj) &&
-    obj.length > 0 &&
-    // if one item in the array is a GraphQLError, we're good
-    obj.some(isGraphQLError)
-  );
-}
-
-/** @private */
-export function isGraphQLError(obj: unknown): obj is GraphQLError {
-  return obj instanceof GraphQLError;
-}
-
-/** @private */
 export function isExecutionResult(val: unknown): val is ExecutionResult {
   return (
     isObject(val) &&
@@ -67,24 +51,4 @@ export function isAsyncIterable<T = unknown>(
   val: unknown,
 ): val is AsyncIterable<T> {
   return typeof Object(val)[Symbol.asyncIterator] === 'function';
-}
-
-/** @private */
-export function jsonErrorReplacer(
-  _key: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  val: any,
-) {
-  if (
-    val instanceof Error &&
-    // GraphQL errors implement their own stringer
-    !isGraphQLError(val)
-  ) {
-    return {
-      // name: val.name, name is included in message
-      message: val.message,
-      // stack: val.stack, can leak sensitive details
-    };
-  }
-  return val;
 }


### PR DESCRIPTION
Client imports the utils.ts which imports a `GraphQLError` instance therefore including it in the bundle. But actually the `graphql` module is only necessary for the handler/server.