### PR TITLE
chore: lock deps for lighthouse implementation

### DIFF
--- a/implementations/lighthouse/Dockerfile
+++ b/implementations/lighthouse/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli
+FROM php:8.1.21-cli
 
 WORKDIR /app
 
@@ -13,5 +13,5 @@ RUN apt-get update && \
         zip \
     && rm -rf /var/lib/apt/lists/*
 RUN composer create-project laravel/laravel /app
-RUN composer require nuwave/lighthouse
+RUN composer require nuwave/lighthouse 6.14.0
 RUN php artisan vendor:publish --tag=lighthouse-schema

--- a/implementations/lighthouse/README.md
+++ b/implementations/lighthouse/README.md
@@ -56,7 +56,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -91,7 +91,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "Internal Server Error",
   "status": 500,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -379,7 +379,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -610,7 +610,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -841,7 +841,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -1072,7 +1072,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -1303,7 +1303,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -1534,7 +1534,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -1765,7 +1765,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -1996,7 +1996,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -2227,7 +2227,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -2458,7 +2458,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -2689,7 +2689,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -2920,7 +2920,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3151,7 +3151,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3382,7 +3382,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3405,7 +3405,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3428,7 +3428,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3451,7 +3451,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3474,7 +3474,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3705,7 +3705,7 @@ The server <i>MAY</i> support these, but are truly optional. These are suggestio
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3941,7 +3941,7 @@ The server <i>SHOULD</i> support these, but is not required.
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3964,7 +3964,7 @@ The server <i>SHOULD</i> support these, but is not required.
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -3999,7 +3999,7 @@ The server <i>SHOULD</i> support these, but is not required.
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -4034,7 +4034,7 @@ The server <i>SHOULD</i> support these, but is not required.
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -4069,7 +4069,7 @@ The server <i>SHOULD</i> support these, but is not required.
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",
@@ -4104,7 +4104,7 @@ The server <i>SHOULD</i> support these, but is not required.
   "statusText": "OK",
   "status": 200,
   "headers": {
-    "x-powered-by": "PHP/8.1.20",
+    "x-powered-by": "PHP/8.1.21",
     "host": "localhost:4000",
     "date": "<timestamp>",
     "content-type": "application/json",


### PR DESCRIPTION
Previously it would auto-update on each image pull which can "pollute" PRs with unnecessary changeset (like [here](https://github.com/graphql/graphql-http/pull/96/commits/a7705ca12bb3e0e57a2023b018dbfd5646eafcae) in #96).