### PR TITLE
Fix: jsonErrorReplacer to use explicit Error type

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -880,10 +880,11 @@ function jsonErrorReplacer(
     // GraphQL errors implement their own stringer
     !isGraphQLError(val)
   ) {
+    const error = val as Error;
     return {
-      // name: val.name, name is included in message
-      message: val.message,
-      // stack: val.stack, can leak sensitive details
+      // name: error.name, name is included in message
+      message: error.message,
+      // stack: error.stack, can leak sensitive details
     };
   }
   return val;


### PR DESCRIPTION
## Description

This PR refactors the jsonErrorReplacer function to use explicit Error casting, improving type safety and preventing potential errors.

## Changes

In the `src/handler.ts` file, the `jsonErrorReplacer` function contains an argument `val` with a type of `any`. However, the function also includes a type check `val instanceof Error`, which allows for a safe cast to the Error type. To leverage this type information, we can introduce a type cast using the `as` keyword, assigning the casted value to a new variable error. This refinement enables the TypeScript compiler to accurately infer the type of error and eliminates any potential type errors.