### PR TITLE
Fix the todo, warning sign not rendered

### DIFF
--- a/src/audits/render.ts
+++ b/src/audits/render.ts
@@ -39,8 +39,7 @@ export async function renderAuditResultsToHTML(results: AuditResult[]) {
     report += `<li><span style="font-family: monospace">💡</span> <b>${grouped.notice.length}</b> notices (suggestions)</li>\n`;
   }
   if (grouped.warn.length) {
-    // TODO: warning sign is rendered as "⚠️" in markdown instead of the emoji
-    report += `<li><span style="font-family: monospace">⚠️</span> <b>${grouped.warn.length}</b> warnings (optional)</li>\n`;
+    report += `<li><span style="font-family: monospace">❗️</span> <b>${grouped.warn.length}</b> warnings (optional)</li>\n`;
   }
   if (grouped.error.length) {
     report += `<li><span style="font-family: monospace">❌</span> <b>${grouped.error.length}</b> errors (required)</li>\n`;

--- a/tests/audits.test.ts
+++ b/tests/audits.test.ts
@@ -119,7 +119,7 @@ describe('Render audit results to HTML', () => {
       <ul>
       <li><b>6</b> audits in total</li>
       <li><span style="font-family: monospace">✅</span> <b>2</b> pass</li>
-      <li><span style="font-family: monospace">⚠️</span> <b>2</b> warnings (optional)</li>
+      <li><span style="font-family: monospace">❗️</span> <b>2</b> warnings (optional)</li>
       <li><span style="font-family: monospace">❌</span> <b>2</b> errors (required)</li>
       </ul>
 


### PR DESCRIPTION
## Overview

Fix the todo of rendering the unicode character as different one, since `(` ⚠️ `)` it's not widely supported across the browsers, therefore I used `(` ❗️ `)` instead, since it's widely supported across all browsers.

## Screenshots

### Old Code

![old code](https://i.imgur.com/8P6t2SV.png)

### Newer Code

![new code](https://i.imgur.com/UYGFuQL.png)