### PR TITLE
fix(audits): incorrect status code range

### DIFF
--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -560,16 +560,21 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
     ),
     audit(
       'B6DC',
-      'MAY use 4xx or 5xx status codes on JSON parsing failure',
+      'MAY use 2xx, 4xx, or 5xx status codes on JSON parsing failure when accepting application/json',
       async () => {
         const res = await fetchFn(await getUrl(opts.url), {
           method: 'POST',
           headers: {
             'content-type': 'application/json',
+            accept: 'application/json',
           },
           body: '{ "not a JSON',
         });
-        ressert(res).status.toBeBetween(400, 499);
+        ressert(res).status.toBeBetweenMultiple([
+          [200, 299],
+          [400, 499],
+          [500, 599],
+        ]);
       },
     ),
     audit(

--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -579,12 +579,13 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
     ),
     audit(
       'BCF8',
-      'MAY use 400 status code on JSON parsing failure',
+      'SHOULD use 400 status code on JSON parsing failure when accepting application/json',
       async () => {
         const res = await fetchFn(await getUrl(opts.url), {
           method: 'POST',
           headers: {
             'content-type': 'application/json',
+            accept: 'application/json',
           },
           body: '{ "not a JSON',
         });

--- a/src/audits/utils.ts
+++ b/src/audits/utils.ts
@@ -99,6 +99,19 @@ export function ressert(res: Response) {
           );
         }
       },
+      toBeBetweenMultiple: (ranges: Array<[number, number]>) => {
+        const isInRange = ranges.some(
+          ([min, max]) => min <= res.status && res.status <= max,
+        );
+        if (!isInRange) {
+          throw new AuditError(
+            res,
+            `Response status is not between any of the provided ranges: ${ranges
+              .map(([min, max]) => `[${min}, ${max}]`)
+              .join(', ')}`,
+          );
+        }
+      },
     },
     header(key: 'content-type') {
       return {

--- a/tests/__snapshots__/audits.test.ts.snap
+++ b/tests/__snapshots__/audits.test.ts.snap
@@ -188,7 +188,7 @@ exports[`should not change globally unique audit ids 1`] = `
   },
   {
     "id": "B6DC",
-    "name": "MAY use 4xx or 5xx status codes on JSON parsing failure",
+    "name": "MAY use 2xx, 4xx, or 5xx status codes on JSON parsing failure when accepting application/json",
   },
   {
     "id": "BCF8",

--- a/tests/__snapshots__/audits.test.ts.snap
+++ b/tests/__snapshots__/audits.test.ts.snap
@@ -192,7 +192,7 @@ exports[`should not change globally unique audit ids 1`] = `
   },
   {
     "id": "BCF8",
-    "name": "MAY use 400 status code on JSON parsing failure",
+    "name": "SHOULD use 400 status code on JSON parsing failure when accepting application/json",
   },
   {
     "id": "8764",


### PR DESCRIPTION
This PR fixes the status code range assertion of audit check B6DC, which did not match the audit name/description.

https://github.com/graphql/graphql-http/blob/a49c45b5afa0173a65e61d87a609e1ee40142032/src/audits/server.ts#L559-L572

The name/description suggests 5xx status codes may be used. However, the audit function currently requires the status code to be between 400 and 499.