### PR TITLE
docs(contributing): fix code formatting command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,5 +54,5 @@ PORT=4000 yarn tsx scripts/audit-implementation.ts implementations/<implementati
 Run the following script to ensure the automatic code formatting is applied:
 
 ```shell
-yarn run lint:fix
+yarn run format
 ```


### PR DESCRIPTION
This PR replaced the non-existent code formatting command mentioned in the contributing docs with the correct `yarn run format` command. Just stumbled across this while formatting my other PR :)

