### PR TITLE
fix(audits): inconsistency between D6D5 and 6A70

### DIFF
--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -474,6 +474,7 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
           },
         });
         ressert(res).status.toBe(200);
+        await ressert(res).bodyAsExecutionResult.notToHaveProperty('errors');
       },
     ),
     audit(


### PR DESCRIPTION
D6D5 and 6A70 essentially perform the same audit check. However, while 6A70 checks that the execution result has no errors, D6D5 does not. This PR updates D6D5 to also check that the execution result has no errors (i.e, make both audit functions do the same assertions).

Relevant code:

https://github.com/graphql/graphql-http/blob/a49c45b5afa0173a65e61d87a609e1ee40142032/src/audits/server.ts#L460-L498

The check that's only present in 6A70 but not in D6D5:

https://github.com/graphql/graphql-http/blob/a49c45b5afa0173a65e61d87a609e1ee40142032/src/audits/server.ts#L496