### PR TITLE
fix(audits): avoid false positives in 9ABE

### DIFF
--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -195,6 +195,7 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
       async () => {
         const res = await fetchFn(await getUrl(opts.url), {
           method: 'POST',
+          body: JSON.stringify({ query: '{ __typename }' }),
         });
         ressert(res).status.toBeBetween(400, 499);
       },

--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -191,7 +191,7 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
     // Request POST
     audit(
       '9ABE',
-      'MAY respond with 4xx status code if content-type is not supplied on POST requests',
+      'SHOULD respond with 4xx status code if content-type is not supplied on POST requests',
       async () => {
         const res = await fetchFn(await getUrl(opts.url), {
           method: 'POST',

--- a/tests/__snapshots__/audits.test.ts.snap
+++ b/tests/__snapshots__/audits.test.ts.snap
@@ -44,7 +44,7 @@ exports[`should not change globally unique audit ids 1`] = `
   },
   {
     "id": "9ABE",
-    "name": "MAY respond with 4xx status code if content-type is not supplied on POST requests",
+    "name": "SHOULD respond with 4xx status code if content-type is not supplied on POST requests",
   },
   {
     "id": "03D4",


### PR DESCRIPTION
The audit function of [9ABE](https://github.com/graphql/graphql-http/blob/a49c45b5afa0173a65e61d87a609e1ee40142032/src/audits/server.ts#L192-L201) sets no `content-type` to trigger a 4xx status code.
However, it also sets no request body, which can also trigger a 4xx status code as per [A5BF](https://github.com/graphql/graphql-http/blob/a49c45b5afa0173a65e61d87a609e1ee40142032/src/audits/server.ts#L210-L220).

This can lead to false positives for this audit check if a server only responds with 4xx because of the missing request body, but not because of the missing `content-type` header.

This PR updates 9ABE to include a valid request body to ensure the 4xx status is triggered based on the missing `content-type` header. Additionally, I updated 9ABE from MAY to SHOULD to match the [relevant part of the spec](https://graphql.github.io/graphql-over-http/draft/#sel-EALLLCAACENn0T).



