### PR TITLE
feat(audit): graphql-response+json parsing failure handling

### DIFF
--- a/src/audits/server.ts
+++ b/src/audits/server.ts
@@ -587,6 +587,21 @@ export function serverAudits(opts: ServerAuditOptions): Audit[] {
       },
     ),
     audit(
+      'B7N8',
+      'SHOULD use 400 status code on JSON parsing failure when accepting application/graphql-response+json',
+      async () => {
+        const res = await fetchFn(await getUrl(opts.url), {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/graphql-response+json',
+          },
+          body: '{ "not a JSON',
+        });
+        ressert(res).status.toBe(400);
+      },
+    ),
+    audit(
       '8764',
       'MAY use 4xx or 5xx status codes if parameters are invalid',
       async () => {

--- a/tests/__snapshots__/audits.test.ts.snap
+++ b/tests/__snapshots__/audits.test.ts.snap
@@ -195,6 +195,10 @@ exports[`should not change globally unique audit ids 1`] = `
     "name": "MAY use 400 status code on JSON parsing failure",
   },
   {
+    "id": "B7N8",
+    "name": "SHOULD use 400 status code on JSON parsing failure when accepting application/graphql-response+json",
+  },
+  {
     "id": "8764",
     "name": "MAY use 4xx or 5xx status codes if parameters are invalid",
   },


### PR DESCRIPTION
This PR is adjacent to #145, and adds an audit check matching [example 6.4.2.1.1](https://graphql.github.io/graphql-over-http/draft/#sec-application-graphql-response-json.Examples.JSON-parsing-failure).

Previously, we had no audit check validating that servers using the `application/graphql-response+json` media type SHOULD respond to not well-formed requests with status code `400`.

For reference, here are the relevant parts of the spec:
- [6.4.2 application/graphql-response+json](https://graphql.github.io/graphql-over-http/draft/#sel-FANNNRCAACENz5F)
- [6.4.2.1.1 JSON parsing failure](https://graphql.github.io/graphql-over-http/draft/#sel-HANNNXFFCAACCP8kC)

Sidenote: I didn't find a convention for the audit IDs, so I generated a random one.